### PR TITLE
Fixed global id parsing in certain cases

### DIFF
--- a/src/main/scala/sangria/relay/GlobalId.scala
+++ b/src/main/scala/sangria/relay/GlobalId.scala
@@ -18,14 +18,14 @@ object GlobalId {
   def toGlobalId(typeName: String, id: String): String = Base64.encode(s"$typeName:$id")
 
   /**
-   * Takes the "global ID" created by toGlobalID, and retuns the type name and ID
+   * Takes the "global ID" created by toGlobalID, and returns the type name and ID
    * used to create it.
    */
   def fromGlobalId(globalId: String) = {
     val decoded = Base64.decode(globalId)
     val idx = decoded.indexOf(":")
 
-    if (idx < 0 && (decoded.size - 1) != idx)
+    if (idx == -1 || idx == decoded.length - 1)
       None
     else
       Some(GlobalId(decoded.substring(0, idx), decoded.substring(idx + 1)))

--- a/src/test/scala/sangria/relay/GlobalIdSpec.scala
+++ b/src/test/scala/sangria/relay/GlobalIdSpec.scala
@@ -144,4 +144,22 @@ class GlobalIdSpec extends WordSpec with Matchers with AwaitSupport {
               "text" → "ipsum"))))
     }
   }
+
+  "GlobalId.fromGlobalId" should {
+    "return None for empty IDs" in {
+      GlobalId.fromGlobalId("") shouldBe empty
+    }
+
+    "return None for incorrect Base64 IDs" in {
+      GlobalId.fromGlobalId("123") shouldBe empty
+    }
+
+    "return None for IDs where the decoded value does not contain a colon" in {
+      GlobalId.fromGlobalId("UG9zdA==") shouldBe empty
+    }
+
+    "return None for IDs where the decoded value does contain a colon at the end" in {
+      GlobalId.fromGlobalId("UG9zdDo=") shouldBe empty
+    }
+  }
 }


### PR DESCRIPTION
It seems that `GlobalId.fromGlobalId` parsing is broken in cases where the string is not a valid base64 string (i.e. shorter than four characters). I ran into `StringIndexOutOfBoundsException`s while validating GlobalIds that where passed in by users.

I added some tests, but I am not sure if they are in the proper form for this project.

`(decoded.size - 1) != idx` seems to have been added to prevent issues when the decoded ID ends with a colon, but I am not 100% sure. If that's the case, that was broken too. If it served a purpose I am not aware of, feel free to fix my code. 😄 

Thank you for maintaining Sangria! 👍 