### PR TITLE
Fixed parsing behaviour of invalid base64 strings

### DIFF
--- a/src/main/scala/sangria/relay/GlobalId.scala
+++ b/src/main/scala/sangria/relay/GlobalId.scala
@@ -22,13 +22,14 @@ object GlobalId {
    * used to create it.
    */
   def fromGlobalId(globalId: String) = {
-    val decoded = Base64.decode(globalId)
-    val idx = decoded.indexOf(":")
+    Base64.decode(globalId) flatMap { decoded =>
+      val idx = decoded.indexOf(":")
 
-    if (idx == -1 || idx == decoded.length - 1)
-      None
-    else
-      Some(GlobalId(decoded.substring(0, idx), decoded.substring(idx + 1)))
+      if (idx == -1 || idx == decoded.length - 1)
+        None
+      else
+        Some(GlobalId(decoded.substring(0, idx), decoded.substring(idx + 1)))
+    }
   }
 
   def unapply(globalId: String) = fromGlobalId(globalId)

--- a/src/main/scala/sangria/relay/util/Base64.scala
+++ b/src/main/scala/sangria/relay/util/Base64.scala
@@ -1,19 +1,19 @@
 package sangria.relay.util
 
-import java.nio.charset.Charset
+import java.nio.charset.StandardCharsets
+
+import scala.util.Try
 
 object Base64 {
   // Java 7 solution. Use java.util.Base64 in Java 8
   import javax.xml.bind.DatatypeConverter
 
-  val `UTF-8` = Charset.forName("UTF-8")
-
   def encode(bytes: Array[Byte]): String =
     DatatypeConverter.printBase64Binary(bytes)
 
   def encode(string: String): String =
-    DatatypeConverter.printBase64Binary(string.getBytes(`UTF-8`))
+    DatatypeConverter.printBase64Binary(string.getBytes(StandardCharsets.UTF_8))
 
-  def decode(base64String: String): String =
-    new String(DatatypeConverter.parseBase64Binary(base64String), `UTF-8`)
+  def decode(base64String: String): Option[String] =
+    Try(DatatypeConverter.parseBase64Binary(base64String)).map(new String(_, StandardCharsets.UTF_8)).toOption
 }

--- a/src/test/scala/sangria/relay/util/Base64Spec.scala
+++ b/src/test/scala/sangria/relay/util/Base64Spec.scala
@@ -23,11 +23,27 @@ class Base64Spec extends WordSpec with Matchers {
     }
 
     "decode base64 string" in {
-      Base64.decode(TestBase64) should be (TestText)
+      Base64.decode(TestBase64) should be (Some(TestText))
     }
 
     "decode UTF-8 base64 string" in {
-      Base64.decode(TestBase64) should be (TestText)
+      Base64.decode(TestBase64) should be (Some(TestText))
+    }
+
+    "return an empty string for an empty string" in {
+      Base64.decode("") should be (Some(""))
+    }
+
+    "return None for base64 strings with to little valid bits" in {
+      Base64.decode("a3222==") should be (None)
+    }
+
+    "return None for base64 strings with invalid characters" in {
+      Base64.decode("foobär23") should be (None)
+    }
+
+    "return None for base64 strings with wrong 4-byte ending unit" in {
+      Base64.decode("TQ=") should be (None)
     }
   }
 }


### PR DESCRIPTION
This is somewhat related to #25. Some global ids still caused weird exceptions that where not easily traceable. As it turned out, those where caused by `javax.xml.bind.DatatypeConverter`which is used to decode the base64 strings.

Most of the exceptions I encountered should never be thrown but caught be the `DatatypeConverter` itself. (See: https://bugs.openjdk.java.net/browse/JDK-8168456) 

Because of that, I changed the implementation that it catches all exceptions that occur during decoding and assumes that the input base64 string is malformed. This might not be 100% correct, but should work just fine in the current context. In addition, I changed the signature of `Base64#decode` to return an `Option` to signal those decoding issues.
