### PR TITLE
Allow custom page info class included in Connection

### DIFF
--- a/src/main/scala/sangria/relay/Connection.scala
+++ b/src/main/scala/sangria/relay/Connection.scala
@@ -25,7 +25,6 @@ object Connection {
     val All = Before :: After :: First :: Last :: Nil
   }
 
-  @annotation.tailrec
   def isValidNodeType[Val](nodeType: OutputType[Val]): Boolean = nodeType match {
     case _: ScalarType[_] | _: EnumType[_] | _: CompositeType[_] ⇒ true
     case OptionType(ofType) ⇒ isValidNodeType(ofType)

--- a/src/main/scala/sangria/relay/Connection.scala
+++ b/src/main/scala/sangria/relay/Connection.scala
@@ -34,19 +34,18 @@ object Connection {
   def definition[Ctx, Conn[_], Val](
     name: String,
     nodeType: OutputType[Val],
-    pageInfoType: OutputType[PageInfo] = DefaultPageInfo.pageInfoType,
     edgeFields: ⇒ List[Field[Ctx, Edge[Val]]] = Nil,
     connectionFields: ⇒ List[Field[Ctx, Conn[Val]]] = Nil
   )(implicit connEv: ConnectionLike[Conn, PageInfo, Val, Edge[Val]], classEv: ClassTag[Conn[Val]]) = {
-    definitionWithEdge[Ctx, PageInfo, Conn, Val, Edge[Val]](name, nodeType, pageInfoType, edgeFields, connectionFields)
+    definitionWithEdge[Ctx, DefaultPageInfo, Conn, Val, Edge[Val]](name, nodeType, edgeFields, connectionFields)
   }
 
   def definitionWithEdge[Ctx, P <: PageInfo, Conn[_], Val, E <: Edge[Val]](
     name: String,
     nodeType: OutputType[Val],
-    pageInfoType: OutputType[P] = DefaultPageInfo.pageInfoType,
     edgeFields: ⇒ List[Field[Ctx, E]] = Nil,
-    connectionFields: ⇒ List[Field[Ctx, Conn[Val]]] = Nil
+    connectionFields: ⇒ List[Field[Ctx, Conn[Val]]] = Nil,
+    pageInfoType: OutputType[P] = DefaultPageInfo.pageInfoType
   )(implicit connEv: ConnectionLike[Conn, P, Val, E], classEv: ClassTag[Conn[Val]], classE: ClassTag[E], classP: ClassTag[P]) = {
     if (!isValidNodeType(nodeType))
       throw new IllegalArgumentException("Node type is invalid. It must be either a Scalar, Enum, Object, Interface, Union, " +

--- a/src/test/scala/sangria/relay/ConnectionSpec.scala
+++ b/src/test/scala/sangria/relay/ConnectionSpec.scala
@@ -85,6 +85,9 @@ class ConnectionSpec extends WordSpec with Matchers with AwaitSupport {
             user {
               friends(first: 2) {
                 totalCount
+                pageInfo {
+                  hasNextPage
+                }
                 edges {
                   friendshipTime
                   node {
@@ -114,6 +117,10 @@ class ConnectionSpec extends WordSpec with Matchers with AwaitSupport {
             "user" → Map(
               "friends" → Map(
                 "totalCount" → 5,
+                "pageInfo" ->
+                  Map(
+                    "hasNextPage" -> true
+                  ),
                 "edges" → List(
                   Map(
                     "friendshipTime" → "Yesterday",

--- a/src/test/scala/sangria/relay/ConnectionWithCustomPageInfoSpec.scala
+++ b/src/test/scala/sangria/relay/ConnectionWithCustomPageInfoSpec.scala
@@ -70,10 +70,27 @@ class ConnectionWithCustomPageInfoSpec extends WordSpec with Matchers with Await
     Field("description", StringType, resolve = _.value.description)
   ))
 
+  val customPageInfoType: ObjectType[Repo, CustomPageInfo] =
+    ObjectType("CustomPageInfo",
+      () => fields(
+        Field("hasNextPage", BooleanType, Some("When paginating forwards, are there more items?"),
+          resolve = _.value.hasNextPage),
+        Field("hasPreviousPage", BooleanType, Some("When paginating backwards, are there more items?"),
+          resolve = _.value.hasPreviousPage),
+        Field("startCursor", OptionType(StringType), Some("When paginating backwards, the cursor to continue."),
+          resolve = _.value.startCursor),
+        Field("endCursor", OptionType(StringType), Some("When paginating forwards, the cursor to continue."),
+          resolve = _.value.endCursor),
+        Field("currentPage", IntType, Some("When paginating, where is the cursor?"),
+          resolve = _.value.currentPage)
+      )
+    )
+
   val ConnectionDefinition(_, taskConnection) =
     Connection.definitionWithEdge[Repo, CustomPageInfo, CustomConnection, Task, Edge[Task]](
       name = "Task",
       nodeType = TaskType,
+      pageInfoType = customPageInfoType,
       pageInfoFields = fields(
         Field("currentPage", IntType, resolve = _.value.currentPage)
       )

--- a/src/test/scala/sangria/relay/ConnectionWithCustomPageInfoSpec.scala
+++ b/src/test/scala/sangria/relay/ConnectionWithCustomPageInfoSpec.scala
@@ -1,0 +1,188 @@
+package sangria.relay
+
+import org.scalatest.{ Matchers, WordSpec }
+import sangria.execution.Executor
+import sangria.parser.QueryParser
+import sangria.relay.util.AwaitSupport
+import sangria.schema._
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.util.Success
+
+class ConnectionWithCustomPageInfoSpec extends WordSpec with Matchers with AwaitSupport {
+
+  /**
+   * custom PageInfo to be included in Connection
+   */
+  case class CustomPageInfo(
+    currentPage: Int,
+    hasNextPage: Boolean = false,
+    hasPreviousPage: Boolean = false,
+    startCursor: Option[String] = None,
+    endCursor: Option[String] = None) extends PageInfo
+
+  /**
+   * custom Connection includes CustomPageInfo
+   */
+  case class CustomConnection[T, P <: PageInfo](
+    pageInfo: CustomPageInfo,
+    edges: Seq[Edge[T]]) extends Connection[T, CustomPageInfo]
+
+  case class User(id: String, name: String)
+  case class Task(id: String, userId: String, description: String)
+
+  case class AccountUser(accountId: String, userId: String, roleId: String)
+
+  class Repo {
+    private val cubert = User("001", "Cubert")
+    private val steve = User("002", "Steve")
+
+    val Users = cubert :: steve :: Nil
+
+    private val pencil = Task("00a", "001", "buy pencil")
+    private val milk = Task("00b", "001", "buy milk")
+
+    private val apple = Task("00c", "002", "buy apple")
+    private val banana = Task("00d", "002", "buy banana")
+    private val orange = Task("00e", "002", "buy orange")
+    private val grape = Task("00f", "002", "buy grape")
+    private val strawberry = Task("00g", "002", "buy strawberry")
+
+    private val Tasks = pencil :: milk :: apple :: banana :: orange :: grape :: strawberry :: Nil
+
+    def getUser(userId: String): User = {
+      Users.find(_.id == userId).get
+    }
+
+    def getTasksForUser(userId: String, limit: Int = 1, offset: Int = 0): (Int, List[Edge[Task]]) = {
+      val totalCounts = Tasks.count { _.userId == userId }
+      val edges: List[Edge[Task]] = Tasks.filter { _.userId == userId }.slice(offset, offset + limit).map {
+        task => Edge(node = task, cursor = task.id)
+      }
+
+      (totalCounts, edges)
+    }
+  }
+
+  val TaskType: ObjectType[Repo, Task] = ObjectType("Task", () => fields(
+    Field("id", StringType, resolve = _.value.id),
+    Field("userId", StringType, resolve = _.value.userId),
+    Field("description", StringType, resolve = _.value.description)
+  ))
+
+  val ConnectionDefinition(_, taskConnection) =
+    Connection.definitionWithEdge[Repo, CustomPageInfo, CustomConnection, Task, Edge[Task]](
+      name = "Task",
+      nodeType = TaskType,
+      pageInfoFields = fields(
+        Field("currentPage", IntType, resolve = _.value.currentPage)
+      )
+    )
+
+  private object Args {
+    val PageNo = Argument("pageNo", IntType)
+    val PageSize = Argument("pageSize", IntType)
+  }
+
+  val UserType: ObjectType[Repo, User] = ObjectType("User", () => fields(
+    Field("id", StringType, resolve = _.value.id),
+    Field("name", StringType, resolve = _.value.name),
+    Field("tasks", taskConnection, arguments = Args.PageNo :: Args.PageSize :: Nil, resolve = {
+      ctx =>
+        val (totalPage, currentPage, edges) = ctx.withArgs(Args.PageNo, Args.PageSize) {
+          (pageNo, pageSize) =>
+            val offset = (pageNo - 1) * pageSize
+            val (totalCount, _edges) = ctx.ctx.getTasksForUser(ctx.value.id, pageSize, offset)
+            val _totalPage = math.ceil(totalCount.toDouble / pageNo.toDouble)
+            (_totalPage.toInt, pageNo, _edges)
+        }
+
+        CustomConnection[Task, CustomPageInfo](
+          CustomPageInfo(
+            currentPage,
+            hasNextPage = currentPage < totalPage,
+            hasPreviousPage = 1 < currentPage
+          ),
+          edges
+        )
+    })
+  ))
+
+  val QueryType = ObjectType("Query", fields[Repo, Unit](
+    Field("users", ListType(UserType), resolve = _.ctx.Users))
+  )
+
+  val schema = Schema(QueryType, additionalTypes = UserType :: TaskType :: Nil)
+
+  "Connection.definitionWithEdge" should {
+    "Includes pageInfo fields correctly" in {
+      val Success(doc) = QueryParser.parse(
+        """
+          query UserQuery {
+            users {
+              id
+              tasks(pageNo: 2, pageSize: 1) {
+                pageInfo {
+                  currentPage
+                 }
+                edges {
+                  node {
+                    id
+                    description
+                  }
+                }
+              }
+            }
+          }
+        """)
+
+      val r = Executor.execute(schema, doc, userContext = new Repo).await
+
+      r should be (
+        Map(
+          "data" -> Map(
+            "users" -> List(
+              Map(
+                "id" -> "001",
+                "tasks" ->
+                  Map(
+                    "pageInfo" -> Map(
+                      "currentPage" -> 2
+                    ),
+                    "edges" -> List(
+                      Map(
+                        "node" ->
+                          Map(
+                            "id" -> "00b",
+                            "description" -> "buy milk"
+                          )
+                      )
+                    )
+                  )
+              ),
+              Map(
+                "id" -> "002",
+                "tasks" ->
+                  Map(
+                    "pageInfo" -> Map(
+                      "currentPage" -> 2
+                    ),
+                    "edges" -> List(
+                      Map(
+                        "node" ->
+                          Map(
+                            "id" -> "00d",
+                            "description" -> "buy banana"
+                          )
+                      )
+                    )
+                  )
+              )
+            )
+          )
+        )
+      )
+    }
+  }
+}
+

--- a/src/test/scala/sangria/relay/ConnectionWithEdgeSpec.scala
+++ b/src/test/scala/sangria/relay/ConnectionWithEdgeSpec.scala
@@ -90,7 +90,7 @@ class ConnectionWithEdgeSpec extends WordSpec with Matchers with AwaitSupport {
 
 
   val ConnectionDefinition(_, userConnection) =
-    Connection.definitionWithEdge[Repo, Connection, User, UserEdge](
+    Connection.definitionWithEdge[Repo, PageInfo, Connection, User, UserEdge](
       name = "User",
       nodeType = UserType,
       edgeFields = fields(


### PR DESCRIPTION
This PR enables `Connection` to contain custom `PageInfo` type.
I changed type of `Connection[T]` to `Connection[+T, +P <: PageInfo]` to represent including customizable `PageInfo` type.

Then, `Connection` has 2 type parameter, however I want avoid to break current APIs, thus it something strange to includes custom PageInfo.

The example code is below.

```scala
  /**
   * custom PageInfo to be included in Connection
   */
  case class CustomPageInfo(
    currentPage: Int,
    hasNextPage: Boolean = false,
    hasPreviousPage: Boolean = false,
    startCursor: Option[String] = None,
    endCursor: Option[String] = None) extends PageInfo

  /**
   * custom Connection includes CustomPageInfo
   */
  case class CustomConnection[T, P <: PageInfo](
    pageInfo: CustomPageInfo,
    edges: Seq[Edge[T]]) extends Connection[T, CustomPageInfo]
```

A type parameter `P` in `CustomConnection[T, P <: PageInfo]` is not necessary, but necessary to not breaking previous APIs.
Is there some good idea?