### PR TITLE
Make edge required in the connection type

### DIFF
--- a/src/main/scala/sangria/relay/Connection.scala
+++ b/src/main/scala/sangria/relay/Connection.scala
@@ -89,9 +89,10 @@ object Connection {
           ),
           Field(
             "edges",
-            OptionType(ListType(OptionType(edgeType))),
+            OptionType(ListType(edgeType)),
             Some("A list of edges."),
-            resolve = ctx => connEv.edges(ctx.value).map(Some(_)))
+            resolve = ctx => connEv.edges(ctx.value)
+          )
         ) ++ connectionFields
     )
 


### PR DESCRIPTION
## What? ## Why?

Currently edges field in connection type looks like `OptionType(ListType(OptionType(edgeType)))` (`edges: [CustomEdge]`) but it seems like it always should be present and it just provides an additionally complexity for the graphql API clients as they should handle this optionality which is probably never the case 

## Breaking change

It shouldn't be a breaking change from the schema perspective as we just trying to remove optionality