### PR TITLE
fix Connection.connectionFromSeq when cursor is after collection end

### DIFF
--- a/src/main/scala/sangria/relay/Connection.scala
+++ b/src/main/scala/sangria/relay/Connection.scala
@@ -138,8 +138,8 @@ object Connection {
       case (_, Some(last)) => Some(arrayLength - last - 1)
       case _ => None
     }
-    val finalAfterMaybe = List(backwardPaginationAfterMaybe, afterOffset).flatten.reduceOption(_ max _)
-
+    val finalAfterMaybe =
+      Iterable(backwardPaginationAfterMaybe, afterOffset).flatten.reduceOption(_ max _)
 
     // before based on after + first
     val forwardPaginationBeforeMaybe = (afterOffset, first) match {
@@ -148,10 +148,13 @@ object Connection {
       case (_, Some(first)) => Some(first)
       case _ => None
     }
-    val finalBeforeMaybe = List(forwardPaginationBeforeMaybe, beforeOffset).flatten.reduceOption(_ min _)
+    val finalBeforeMaybe =
+      Iterable(forwardPaginationBeforeMaybe, beforeOffset).flatten.reduceOption(_ min _)
 
     // align slice indices with all edges indices
-    val sliceWithIdx = arraySlice.iterator.zipWithIndex.map { case (e, idx) => (e, idx + sliceStart) }
+    val sliceWithIdx = arraySlice.iterator.zipWithIndex.map { case (e, idx) =>
+      (e, idx + sliceStart)
+    }
     val trimmedSlice = sliceWithIdx.filter { case (_, idx) =>
       finalAfterMaybe.forall(_ < idx) && finalBeforeMaybe.forall(_ > idx)
     }.toList

--- a/src/test/scala/sangria/relay/ConnectionFromSeqSpec.scala
+++ b/src/test/scala/sangria/relay/ConnectionFromSeqSpec.scala
@@ -532,5 +532,25 @@ class ConnectionFromSeqSpec extends AnyWordSpec with Matchers with AwaitSupport 
           List(Edge("D", CursorOfD))
         ))
     }
+
+    "Retruns no elements and proper hasPreviousPage/hasNextPage when cursor out of range" in {
+      connectionFromSeq(
+        List.empty,
+        ConnectionArgs(
+          first = Some(2),
+          // after 10th
+          after = Some("YXJyYXljb25uZWN0aW9uOjEw")
+        ),
+        SliceInfo(10, 4)) should be(
+        DefaultConnection(
+          PageInfo(
+            startCursor = None,
+            endCursor = None,
+            hasPreviousPage = true,
+            hasNextPage = false
+          ),
+          List.empty
+        ))
+    }
   }
 }


### PR DESCRIPTION
We faced an issue with Connection.connectionFromSeq where some items in the collection were removed while it was being browsed, causing the next page cursor to point beyond the end of the collection. When this next page was opened, no items were returned, which was expected. However, hasNextPage was incorrectly returning true.

In our case, a bot was traversing the dataset. Since no items were returned, the after cursor was set to null, causing the bot to restart browsing the collection from the beginning.

In summary for input:
```
connectionFromSeq(
  List.empty,
  ConnectionArgs(
    first = Some(2),
    after = Some(after10th)
  ),
  SliceInfo(10, 4)
)
```
The method should return page info:
```
PageInfo(
  startCursor = None,
  endCursor = None,
  hasPreviousPage = true,
  hasNextPage = false
)
```
but previous implementation returned:
```
PageInfo(
  startCursor = None,
  endCursor = None,
  hasPreviousPage = true,
  hasNextPage = true <- there is no next page since `after` is greater than total number of items
)
```
.
